### PR TITLE
Make Claude Code feature container public

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,4 @@ jobs:
           publish-features: "true"
           base-path-to-features: "./src"
           github-token: ${{secrets.GITHUB_TOKEN}}
+          features-visibility: "public"

--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Claude Code CLI",
     "id": "claude-code",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs the Claude Code CLI globally",
     "options": {},
     "documentationURL": "https://github.com/anthropics/devcontainer-features/tree/main/src/claude-code",


### PR DESCRIPTION
## Summary
- Add `features-visibility: \"public\"` to the workflow configuration to make the published features publicly accessible
- This allows anyone to use the Claude Code CLI devcontainer feature without authentication

🤖 Generated with [Claude Code](https://claude.ai/code)